### PR TITLE
Update Global RLQS client to send immediate reports for new buckets

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
@@ -92,8 +92,10 @@ public:
 
 private:
   // Build usage reports (i.e., the request sent to RLQS server) from the
-  // buckets in quota bucket cache.
+  // buckets in quota bucket cache. If specified, the usage reports will only
+  // include the given bucket.
   RateLimitQuotaUsageReports buildReports();
+  RateLimitQuotaUsageReports buildReports(std::shared_ptr<CachedBucket> cached_bucket);
 
   // Helpers to write to TLS.
   // Copy source-of-truth BucketsCache & pointer-swap/write to TLS.


### PR DESCRIPTION
Commit Message: Update the global RLQS client to send an immediate report when each RLQS bucket is first matched.

Additional Description: Sending an immediate report notifies the RLQS backend of the new bucket's usage, rather than waiting for the next reporting cycle (whose interval could be quite long).

Risk Level: Minor (filter in development)
Testing: Unit and integration testing.
Docs Changes:
Release Notes: