### PR TITLE
rlqs: implement preview matchers

### DIFF
--- a/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
+++ b/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
@@ -33,7 +33,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 //
 // Can be overridden in the per-route and per-host configurations.
 // The more specific definition completely overrides the less specific definition.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RateLimitQuotaFilterConfig {
   // Configures the gRPC Rate Limit Quota Service (RLQS) RateLimitQuotaService.
   config.core.v3.GrpcService rlqs_server = 1 [(validate.rules).message = {required: true}];
@@ -136,6 +136,23 @@ message RateLimitQuotaFilterConfig {
   // filter is enabled but not enforced.
   repeated config.core.v3.HeaderValueOption request_headers_to_add_when_not_enforced = 6
       [(validate.rules).repeated = {max_items: 10}];
+
+  // Optional matcher tree to use when previewing the effects of new bucket
+  // matchers.
+  //
+  // If set, the filter will separately match against the
+  // ``preview_bucket_matchers`` and ``bucket_matchers`` trees. Between the
+  // selected buckets, if the preview bucket is higher priority than the
+  // actionable bucket, the preview bucket is logged & its usage recorded before
+  // executing against the actionable bucket.
+  //
+  // Note: evaluating the preview matcher can still affect rate limiting
+  // decisions if configured to target a bucket that is already in-use.
+  // The recommended solution is to target buckets not referenced in
+  // ``bucket_matchers`` when writing preview matchers.
+  //
+  // Regarding field formatting, reference ``bucket_matchers`` for examples.
+  xds.type.matcher.v3.Matcher preview_bucket_matchers = 7;
 }
 
 // Per-route and per-host configuration overrides. The more specific definition completely
@@ -165,7 +182,7 @@ message RateLimitQuotaOverride {
 // ``bucket_matchers`` matcher tree to assign the matched requests to the Quota Bucket.
 // Usage example: :ref:`RateLimitQuotaFilterConfig.bucket_matchers
 // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig.bucket_matchers>`.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message RateLimitQuotaBucketSettings {
   // Configures the behavior after the first request has been matched to the bucket, and before the
   // the RLQS server returns the first quota assignment.
@@ -420,4 +437,11 @@ message RateLimitQuotaBucketSettings {
   // :ref:`AbandonAction <envoy_v3_api_msg_service.rate_limit_quota.v3.RateLimitQuotaResponse.BucketAction.AbandonAction>`
   // message.
   ExpiredAssignmentBehavior expired_assignment_behavior = 5;
+
+  // The priority of the bucket.
+  //
+  // Priority is used to determine the selected bucket when a request matches
+  // against multiple (e.g. preview & actionable buckets). A lower value
+  // has higher priority: 0 -> max_int64 is highest -> lowest priority.
+  int64 priority = 6;
 }

--- a/source/extensions/filters/http/rate_limit_quota/config.cc
+++ b/source/extensions/filters/http/rate_limit_quota/config.cc
@@ -83,8 +83,8 @@ Http::FilterFactoryCb RateLimitQuotaFilterFactory::createFilterFactoryFromProtoT
     matcher = matcher_factory.create(config->bucket_matchers())();
   }
 
-  return [&, config = std::move(config), config_with_hash_key, tls_store,
-          matcher](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+  return [&, config = std::move(config), config_with_hash_key, tls_store = std::move(tls_store),
+          matcher = std::move(matcher)](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     std::unique_ptr<RateLimitClient> local_client =
         createLocalRateLimitClient(tls_store->global_client_tls, tls_store->buckets_tls);
 

--- a/source/extensions/filters/http/rate_limit_quota/config.cc
+++ b/source/extensions/filters/http/rate_limit_quota/config.cc
@@ -82,14 +82,19 @@ Http::FilterFactoryCb RateLimitQuotaFilterFactory::createFilterFactoryFromProtoT
   if (config->has_bucket_matchers()) {
     matcher = matcher_factory.create(config->bucket_matchers())();
   }
+  Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> preview_matcher = nullptr;
+  if (config->has_preview_bucket_matchers()) {
+    preview_matcher = matcher_factory.create(config->preview_bucket_matchers())();
+  }
 
   return [&, config = std::move(config), config_with_hash_key, tls_store = std::move(tls_store),
-          matcher = std::move(matcher)](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+          matcher = std::move(matcher), preview_matcher = std::move(preview_matcher)](
+             Http::FilterChainFactoryCallbacks& callbacks) -> void {
     std::unique_ptr<RateLimitClient> local_client =
         createLocalRateLimitClient(tls_store->global_client_tls, tls_store->buckets_tls);
 
     callbacks.addStreamFilter(std::make_shared<RateLimitQuotaFilter>(
-        config, context, std::move(local_client), config_with_hash_key, matcher));
+        config, context, std::move(local_client), config_with_hash_key, matcher, preview_matcher));
   };
 }
 

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -95,7 +95,7 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
   callbacks_->streamInfo().setDynamicMetadata(kBucketMetadataNamespace, bucket_log);
 
   std::shared_ptr<CachedBucket> cached_bucket = client_->getBucket(bucket_id);
-  if (cached_bucket) {
+  if (cached_bucket != nullptr) {
     // Found the cached bucket entry.
     return processCachedBucket(*cached_bucket);
   }
@@ -162,14 +162,14 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
   // Initialize the data pointer on first use and reuse it for subsequent
   // requests. This avoids creating the data object for every request, which
   // is expensive.
-  if (!data_ptr_) {
-    if (!callbacks_) {
+  if (data_ptr_ == nullptr) {
+    if (callbacks_ == nullptr) {
       return absl::InternalError("Filter callback has not been initialized successfully yet.");
     }
     data_ptr_ = std::make_unique<Http::Matching::HttpMatchingDataImpl>(callbacks_->streamInfo());
   }
 
-  if (!matcher_) {
+  if (matcher_ == nullptr) {
     return absl::InternalError("Matcher tree has not been initialized yet.");
   }
   // Populate the request header.

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -30,6 +30,8 @@ namespace HttpFilters {
 namespace RateLimitQuota {
 
 const char kBucketMetadataNamespace[] = "envoy.extensions.http_filters.rate_limit_quota.bucket";
+const char kPreviewBucketMetadataNamespace[] =
+    "envoy.extensions.http_filters.rate_limit_quota.preview_bucket";
 
 using envoy::type::v3::RateLimitStrategy;
 using NoAssignmentBehavior = envoy::extensions::filters::http::rate_limit_quota::v3::
@@ -46,32 +48,18 @@ bool noAssignmentBehaviorShouldAllow(const NoAssignmentBehavior& no_assignment_b
 
 Http::FilterHeadersStatus sendDenyResponse(Http::StreamDecoderFilterCallbacks* cb,
                                            Envoy::Http::Code code,
-                                           StreamInfo::CoreResponseFlag flag) {
-  cb->sendLocalReply(code, "", nullptr, absl::nullopt, "");
-  cb->streamInfo().setResponseFlag(flag);
+                                           StreamInfo::CoreResponseFlag flag, bool preview) {
+  if (!preview) {
+    cb->sendLocalReply(code, "", nullptr, absl::nullopt, "");
+    cb->streamInfo().setResponseFlag(flag);
+  }
   return Envoy::Http::FilterHeadersStatus::StopIteration;
 }
 
-Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeaderMap& headers,
-                                                              bool end_stream) {
-  ENVOY_LOG(trace, "decodeHeaders: end_stream = {}", end_stream);
-  // First, perform the request matching.
-  absl::StatusOr<Matcher::ActionPtr> match_result = requestMatching(headers);
-  if (!match_result.ok()) {
-    // When the request is not matched by any matchers, it is ALLOWED by default
-    // (i.e., fail-open) and its quota usage will not be reported to RLQS
-    // server.
-    // TODO(tyxia) Add stats here and other places throughout the filter. e.g.
-    // request allowed/denied, matching succeed/fail and so on.
-    ENVOY_LOG(debug,
-              "The request is not matched by any matchers: ", match_result.status().message());
-    return Envoy::Http::FilterHeadersStatus::Continue;
-  }
-
-  // Second, generate the bucket id for this request based on match action when
-  // the request matching succeeds.
-  const RateLimitOnMatchAction& match_action =
-      match_result.value()->getTyped<RateLimitOnMatchAction>();
+Http::FilterHeadersStatus
+RateLimitQuotaFilter::executeMatchedAction(const RateLimitOnMatchAction& match_action,
+                                           bool preview) {
+  // Generate the bucket id for this request based on matched action.
   absl::StatusOr<BucketId> ret =
       match_action.generateBucketId(*data_ptr_, factory_context_, visitor_);
   if (!ret.ok()) {
@@ -92,12 +80,14 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
   for (const auto& bucket : bucket_id_proto.bucket()) {
     (*bucket_log_fields)[bucket.first] = ValueUtil::stringValue(bucket.second);
   }
-  callbacks_->streamInfo().setDynamicMetadata(kBucketMetadataNamespace, bucket_log);
+
+  callbacks_->streamInfo().setDynamicMetadata(
+      (preview) ? kPreviewBucketMetadataNamespace : kBucketMetadataNamespace, bucket_log);
 
   std::shared_ptr<CachedBucket> cached_bucket = client_->getBucket(bucket_id);
   if (cached_bucket != nullptr) {
     // Found the cached bucket entry.
-    return processCachedBucket(*cached_bucket);
+    return processCachedBucket(*cached_bucket, preview);
   }
 
   // New buckets should have a configured default action pulled from
@@ -152,13 +142,59 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeade
   }
 
   return sendDenyResponse(callbacks_, Envoy::Http::Code::TooManyRequests,
-                          StreamInfo::CoreResponseFlag::ResponseFromCacheFilter);
+                          StreamInfo::CoreResponseFlag::ResponseFromCacheFilter, preview);
+}
+
+Http::FilterHeadersStatus RateLimitQuotaFilter::decodeHeaders(Http::RequestHeaderMap& headers,
+                                                              bool end_stream) {
+  ENVOY_LOG(trace, "decodeHeaders: end_stream = {}", end_stream);
+
+  // First, perform the request matching against both actionable & preview
+  // matchers. The preview matcher is optional.
+  absl::StatusOr<Matcher::ActionPtr> preview_match_result = nullptr;
+  if (preview_matcher_ != nullptr) {
+    preview_match_result = requestMatching(preview_matcher_.get(), headers);
+  }
+  absl::StatusOr<Matcher::ActionPtr> match_result = requestMatching(matcher_.get(), headers);
+
+  absl::optional<RateLimitOnMatchAction> preview_match_action = std::nullopt;
+  if (preview_match_result.ok() && *preview_match_result) {
+    preview_match_action = preview_match_result.value()->getTyped<RateLimitOnMatchAction>();
+  }
+  absl::optional<RateLimitOnMatchAction> match_action = std::nullopt;
+  if (match_result.ok()) {
+    match_action = match_result.value()->getTyped<RateLimitOnMatchAction>();
+  }
+
+  // Second, determine whether or not to evaluate a matched preview bucket.
+  // It should be evaluated if it has a higher priority than the matched,
+  // actionable bucket (or if no actionable bucket was matched).
+  if (preview_match_action.has_value() &&
+      (!match_action.has_value() || preview_match_action->bucketSettings().priority() <=
+                                        match_action->bucketSettings().priority())) {
+    // Disregard the allow/deny decision of the preview bucket's execution.
+    executeMatchedAction(*preview_match_action, true);
+  }
+
+  // If the request is not matched by any matchers, it is ALLOWED by default
+  // (i.e., fail-open) and its quota usage will not be reported to RLQS
+  // server.
+  if (!match_action.has_value()) {
+    // TODO(tyxia) Add stats here and other places throughout the filter. e.g.
+    // request allowed/denied, matching succeed/fail and so on.
+    ENVOY_LOG(debug,
+              "The request is not matched by any matchers: ", match_result.status().message());
+    return Envoy::Http::FilterHeadersStatus::Continue;
+  }
+
+  return executeMatchedAction(*match_action, false);
 }
 
 // TODO(tyxia) Currently request matching is only performed on the request
 // header.
 absl::StatusOr<Matcher::ActionPtr>
-RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
+RateLimitQuotaFilter::requestMatching(Matcher::MatchTree<Http::HttpMatchingData>* matcher,
+                                      const Http::RequestHeaderMap& headers) {
   // Initialize the data pointer on first use and reuse it for subsequent
   // requests. This avoids creating the data object for every request, which
   // is expensive.
@@ -169,7 +205,7 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
     data_ptr_ = std::make_unique<Http::Matching::HttpMatchingDataImpl>(callbacks_->streamInfo());
   }
 
-  if (matcher_ == nullptr) {
+  if (matcher == nullptr) {
     return absl::InternalError("Matcher tree has not been initialized yet.");
   }
   // Populate the request header.
@@ -178,7 +214,7 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
   }
 
   // Perform the matching.
-  auto match_result = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, *data_ptr_);
+  auto match_result = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher, *data_ptr_);
   if (match_result.match_state_ != Matcher::MatchState::MatchComplete) {
     // The returned state from `evaluateMatch` function is `MatchState::UnableToMatch` here.
     return absl::InternalError("Unable to match due to the required data not being available.");
@@ -237,7 +273,8 @@ bool RateLimitQuotaFilter::shouldAllowRequest(const CachedBucket& cached_bucket)
   return true; // Unreachable.
 }
 
-Http::FilterHeadersStatus RateLimitQuotaFilter::processCachedBucket(CachedBucket& cached_bucket) {
+Http::FilterHeadersStatus RateLimitQuotaFilter::processCachedBucket(CachedBucket& cached_bucket,
+                                                                    bool preview) {
   // The QuotaUsage of a cached bucket should never be null. If it is due to a
   // bug, this will crash.
   std::shared_ptr<QuotaUsage> quota_usage = cached_bucket.quota_usage;
@@ -251,7 +288,7 @@ Http::FilterHeadersStatus RateLimitQuotaFilter::processCachedBucket(CachedBucket
   // TODO(tyxia) Build the customized response based on
   // `DenyResponseSettings` if it is configured.
   return sendDenyResponse(callbacks_, Envoy::Http::Code::TooManyRequests,
-                          StreamInfo::CoreResponseFlag::ResponseFromCacheFilter);
+                          StreamInfo::CoreResponseFlag::ResponseFromCacheFilter, preview);
 }
 
 } // namespace RateLimitQuota

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
@@ -203,7 +203,7 @@ void GlobalRateLimitClientImpl::createBucketImpl(const BucketId& bucket_id, size
   sendUsageReportImpl(initial_report);
 
   writeBucketsToTLS();
-  if (callbacks_) {
+  if (callbacks_ != nullptr) {
     callbacks_->onBucketCreated(buckets_cache_[id]->bucket_id, id);
   }
 }
@@ -257,7 +257,7 @@ createTokenBucketFromAction(const RateLimitStrategy& strategy, TimeSource& time_
 }
 
 void GlobalRateLimitClientImpl::onReceiveMessage(RateLimitQuotaResponsePtr&& response) {
-  if (!response) {
+  if (response == nullptr) {
     return;
   }
   main_dispatcher_.post(
@@ -359,7 +359,7 @@ void GlobalRateLimitClientImpl::onQuotaResponseImpl(const RateLimitQuotaResponse
   }
   // Push updates to TLS.
   writeBucketsToTLS();
-  if (callbacks_) {
+  if (callbacks_ != nullptr) {
     callbacks_->onQuotaResponseProcessed();
   }
 }
@@ -388,13 +388,13 @@ bool GlobalRateLimitClientImpl::startStreamImpl() {
 }
 
 void GlobalRateLimitClientImpl::startSendReportsTimerImpl() {
-  if (send_reports_timer_) {
+  if (send_reports_timer_ != nullptr) {
     return;
   }
   ENVOY_LOG(debug, "Start the usage reporting timer for the RLQS stream.");
   send_reports_timer_ = main_dispatcher_.createTimer([&]() {
     onSendReportsTimer();
-    if (callbacks_) {
+    if (callbacks_ != nullptr) {
       callbacks_->onUsageReportsSent();
     }
     send_reports_timer_->enableTimer(send_reports_interval_);
@@ -420,7 +420,7 @@ void GlobalRateLimitClientImpl::startActionExpirationTimer(CachedBucket* cached_
   // Pointer safety as all writes are against the source-of-truth.
   cached_bucket->action_expiration_timer = main_dispatcher_.createTimer([&, id, cached_bucket]() {
     onActionExpirationTimer(cached_bucket, id);
-    if (callbacks_) {
+    if (callbacks_ != nullptr) {
       callbacks_->onActionExpiration();
     }
   });
@@ -442,7 +442,7 @@ void GlobalRateLimitClientImpl::onActionExpirationTimer(CachedBucket* bucket, si
 
   // Without a fallback action, the cached action will be deleted and the bucket
   // will revert to its default action.
-  if (!cached_bucket->fallback_action) {
+  if (cached_bucket->fallback_action == nullptr) {
     ENVOY_LOG(debug,
               "No fallback action is configured for bucket id {}, reverting to "
               "its default action.",
@@ -509,7 +509,7 @@ void GlobalRateLimitClientImpl::startFallbackExpirationTimer(CachedBucket* cache
   // Pointer safety as all writes are against the source-of-truth.
   cached_bucket->fallback_expiration_timer = main_dispatcher_.createTimer([&, id, cached_bucket]() {
     onFallbackExpirationTimer(cached_bucket, id);
-    if (callbacks_) {
+    if (callbacks_ != nullptr) {
       callbacks_->onFallbackExpiration();
     }
   });

--- a/test/extensions/filters/http/rate_limit_quota/client_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/client_test.cc
@@ -242,7 +242,7 @@ void setAtomic(uint64_t value, std::atomic<uint64_t>& counter) {
 absl::StatusOr<std::shared_ptr<CachedBucket>>
 tryGetBucket(ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_tls, size_t id) {
   auto cache_ref = buckets_tls.get();
-  if (!cache_ref.has_value() || !cache_ref->quota_buckets_)
+  if (!cache_ref.has_value() || cache_ref->quota_buckets_ == nullptr)
     return absl::NotFoundError("Bucket TLS not initialized");
 
   auto bucket_it = cache_ref->quota_buckets_->find(id);

--- a/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
+++ b/test/extensions/filters/http/rate_limit_quota/client_test_utils.h
@@ -119,7 +119,7 @@ public:
   }
 
   inline static Event::MockTimer* assertMockTimer(Event::Timer* timer) {
-    if (!timer)
+    if (timer == nullptr)
       return nullptr;
     return dynamic_cast<Event::MockTimer*>(timer);
   }

--- a/test/extensions/filters/http/rate_limit_quota/integration_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/integration_test.cc
@@ -196,7 +196,7 @@ protected:
   }
 
   void cleanUp() {
-    if (rlqs_connection_) {
+    if (rlqs_connection_ != nullptr) {
       ASSERT_TRUE(rlqs_connection_->close());
       ASSERT_TRUE(rlqs_connection_->waitForDisconnect());
     }

--- a/test/extensions/filters/http/rate_limit_quota/test_utils.h
+++ b/test/extensions/filters/http/rate_limit_quota/test_utils.h
@@ -43,6 +43,50 @@ inline constexpr absl::string_view ValidMatcherConfig = R"EOF(
                         "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
                         header_name: group
             reporting_interval: 60s
+            priority: 1
+  )EOF";
+
+inline constexpr absl::string_view ValidLowPriorityMatcherConfig = R"EOF(
+  matcher_list:
+    matchers:
+      # Assign requests with header['env'] set to 'staging' to the bucket { name: 'staging' }
+      predicate:
+        single_predicate:
+          input:
+            typed_config:
+              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+              header_name: environment
+            name: "HttpRequestHeaderMatchInput"
+          value_match:
+            exact: staging
+      on_match:
+        action:
+          name: rate_limit_quota
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings
+            bucket_id_builder:
+              bucket_id_builder:
+                "name":
+                    string_value: "prod"
+                "priority_test":
+                    string_value: "low_priority"
+                "environment":
+                    custom_value:
+                      name: "test_1"
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                        header_name: environment
+                "group":
+                    custom_value:
+                      name: "test_2"
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                        header_name: group
+            reporting_interval: 60s
+            priority: 100
+            no_assignment_behavior:
+              fallback_rate_limit:
+                blanket_rule: DENY_ALL
   )EOF";
 
 inline constexpr absl::string_view InvalidMatcherConfig = R"EOF(


### PR DESCRIPTION
Commit Message:
- Preview matchers are provided to enable testing how a config *would* have treated incoming traffic.
  - The preview matcher tree and the actionable matcher tree are both checked against each incoming request.
  - The selected, actionable matcher will always determine the allow/deny decision for the request.
  - The preview matcher will go through full evaluation (bucket usage caching, etc) but the resulting allow/deny decision will not be enforced.
    - Preview matching & evaluation will populate dynamic metadata to make test results visible on the Envoy and the RLQS server will see usage reports, generate responses, etc as normal for server-side visibility.
- Both the actionable and preview matchers are given an optional priority value, to determine behavior when both the actionable and preview matchers match on a given request.
  - If the selected, actionable matcher has higher priority, then the preview matcher will not be evaluated.
  - If both have the same priority or the preview matcher has higher priority, then both matchers will be evaluated fully.

Risk Level:
Testing: Unit testing, manual testing WIP
Docs Changes:
Release Notes:
Platform Specific Features:

