### PR TITLE
Centralize keep_matching & sub-matcher recursion handling in evaluateMatch(...)

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -157,55 +157,14 @@ public:
     const absl::optional<OnMatch<DataType>> on_match_;
     // Non-null if the match was completed and the match tree can be re-entered to check for
     // additional matches from where the initial matching stopped.
-    std::unique_ptr<MatchTree<DataType>> matcher_reentrant_ = nullptr;
+    MatchTreePtr<DataType> matcher_reentrant_ = nullptr;
   };
 
   // Attempts to match against the matching data (which should contain all the data requested via
   // matching requirements). If the match couldn't be completed, {false, {}} will be returned.
   // If a match result was determined, {true, action} will be returned. If a match result was
   // determined to be no match, {true, {}} will be returned.
-  MatchResult match(const DataType& data,
-                    std::vector<OnMatch<DataType>>* skipped_matches = nullptr) {
-    MatchResult result = doMatch(data);
-    // Special handling for matchers set to be skipped via the keep_matching flag.
-    if (shouldSkipMatch(result)) {
-      return skipAndReenter(result, data, skipped_matches);
-    }
-    return result;
-  }
-
-protected:
-  // Matching logic for MatchTree children to implement. The match() function handles universally
-  // applied logic, e.g. handling the keep_matching flag.
-  virtual MatchResult doMatch(const DataType& matching_data) PURE;
-
-  static inline MatchResult skipAndReenter(MatchResult& initial_result, const DataType& data,
-                                           std::vector<OnMatch<DataType>>* skipped_matches) {
-    // MatchResult is immutable so individual fields must be saved if needed between iterations.
-    std::unique_ptr<MatchTree<DataType>> matcher_reentrant =
-        std::move(initial_result.matcher_reentrant_);
-    if (skipped_matches)
-      skipped_matches->push_back(initial_result.on_match_.value());
-    // While continuing to hit skipped matches and while reentrants are still returned, continue
-    // matching.
-    while (matcher_reentrant) {
-      MatchResult result = matcher_reentrant->doMatch(data);
-      if (shouldSkipMatch(result)) {
-        if (skipped_matches)
-          skipped_matches->push_back(result.on_match_.value());
-        matcher_reentrant = std::move(result.matcher_reentrant_);
-        continue;
-      }
-      return result;
-    }
-    // Ran out of reentrants, return no-match.
-    return {MatchState::MatchComplete, {}};
-  }
-
-  static inline bool shouldSkipMatch(const MatchResult& result) {
-    return (result.match_state_ == MatchState::MatchComplete && result.on_match_.has_value() &&
-            result.on_match_->keep_matching_);
-  }
+  virtual MatchResult match(const DataType& matching_data) PURE;
 };
 
 template <class DataType> using MatchTreeSharedPtr = std::shared_ptr<MatchTree<DataType>>;

--- a/source/common/matcher/list_matcher.h
+++ b/source/common/matcher/list_matcher.h
@@ -44,9 +44,8 @@ public:
     return {MatchState::MatchComplete, on_no_match, nullptr};
   }
 
-protected:
   // MatchTree interface match logic implementation.
-  typename MatchTree<DataType>::MatchResult doMatch(const DataType& matching_data) override {
+  typename MatchTree<DataType>::MatchResult match(const DataType& matching_data) override {
     return ListMatcher<DataType>::matchImpl(matching_data, matchers_, on_no_match_);
   }
 
@@ -64,8 +63,7 @@ public:
       : parent_matchers_(parent_matchers), on_no_match_(on_no_match),
         starting_index_(starting_index) {}
 
-protected:
-  typename MatchTree<DataType>::MatchResult doMatch(const DataType& matching_data) override {
+  typename MatchTree<DataType>::MatchResult match(const DataType& matching_data) override {
     return ListMatcher<DataType>::matchImpl(matching_data, *parent_matchers_, on_no_match_,
                                             starting_index_);
   }

--- a/source/common/matcher/map_matcher.h
+++ b/source/common/matcher/map_matcher.h
@@ -19,8 +19,7 @@ public:
   // Adds a child to the map.
   virtual void addChild(std::string value, OnMatch<DataType>&& on_match) PURE;
 
-protected:
-  typename MatchTree<DataType>::MatchResult doMatch(const DataType& data) override {
+  typename MatchTree<DataType>::MatchResult match(const DataType& data) override {
     const auto input = data_input_->get(data);
     ENVOY_LOG(trace, "Attempting to match {}", input);
     if (input.data_availability_ == DataInputGetResult::DataAvailability::NotAvailable) {
@@ -32,13 +31,9 @@ protected:
       return {MatchState::MatchComplete, on_no_match_};
     }
 
-    const auto result = doMatch(absl::get<std::string>(input.data_));
-    if (result) {
-      if (result->matcher_) {
-        return result->matcher_->match(data);
-      } else {
-        return {MatchState::MatchComplete, *result};
-      }
+    const absl::optional<OnMatch<DataType>> result = doMatch(absl::get<std::string>(input.data_));
+    if (result.has_value()) {
+      return {MatchState::MatchComplete, *result};
     } else if (input.data_availability_ ==
                DataInputGetResult::DataAvailability::MoreDataMightBeAvailable) {
       // It's possible that we were attempting a lookup with a partial value, so delay matching

--- a/test/common/matcher/list_matcher_test.cc
+++ b/test/common/matcher/list_matcher_test.cc
@@ -62,32 +62,33 @@ TEST(ListMatcherTest, Reentry) {
 
 TEST(ListMatcherTest, KeepMatching) {
   // Expect a no-match return due to keep_matching = true.
-  Envoy::Matcher::ListMatcher<TestData> matcher(absl::nullopt);
+  Envoy::Matcher::ListMatcher<TestData> matcher(stringOnMatch<TestData>("on no match"));
   matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
                      stringOnMatch<TestData>("keep matching 1", /*keep_matching=*/true));
   matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
+                     stringOnMatch<TestData>("match", /*keep_matching=*/false));
+  matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
                      stringOnMatch<TestData>("keep matching 2", /*keep_matching=*/true));
-  matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
-                     stringOnMatch<TestData>("match 1", /*keep_matching=*/false));
-  matcher.addMatcher(createSingleMatcher("string", [](auto) { return true; }),
-                     stringOnMatch<TestData>("keep matching 3", /*keep_matching=*/true));
 
-  // If given a skipped_matches vector, expect the skipped match to be recorded.
-  std::vector<OnMatch<TestData>> skipped_matches{};
-  auto result = matcher.match(TestData(), &skipped_matches);
-  verifyImmediateMatch(result, "match 1");
-  ASSERT_EQ(skipped_matches.size(), 2);
-  verifyOnMatch(skipped_matches.at(0), "keep matching 1");
-  verifyOnMatch(skipped_matches.at(1), "keep matching 2");
-  skipped_matches.clear();
-  ASSERT_NE(result.matcher_reentrant_, nullptr);
+  auto result_1 = matcher.match(TestData());
+  verifyImmediateMatch(result_1, "keep matching 1");
+  EXPECT_NE(result_1.matcher_reentrant_, nullptr);
+  EXPECT_TRUE(result_1.on_match_->keep_matching_);
 
-  auto result_2 = result.matcher_reentrant_->match(TestData(), &skipped_matches);
-  verifyNoMatch(result_2);
-  ASSERT_EQ(skipped_matches.size(), 1);
-  verifyOnMatch(skipped_matches.at(0), "keep matching 3");
-  skipped_matches.clear();
-  ASSERT_EQ(result_2.matcher_reentrant_, nullptr);
+  auto result_2 = result_1.matcher_reentrant_->match(TestData());
+  verifyImmediateMatch(result_2, "match");
+  EXPECT_NE(result_2.matcher_reentrant_, nullptr);
+  EXPECT_FALSE(result_2.on_match_->keep_matching_);
+
+  auto result_3 = result_2.matcher_reentrant_->match(TestData());
+  verifyImmediateMatch(result_3, "keep matching 2");
+  EXPECT_NE(result_3.matcher_reentrant_, nullptr);
+  EXPECT_TRUE(result_3.on_match_->keep_matching_);
+
+  auto result_4 = result_3.matcher_reentrant_->match(TestData());
+  verifyImmediateMatch(result_4, "on no match");
+  EXPECT_FALSE(result_4.on_match_->keep_matching_);
+  EXPECT_EQ(result_4.matcher_reentrant_, nullptr);
 }
 
 } // namespace

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -107,7 +107,7 @@ MATCHER(HasSubMatcher, "") {
   return true;
 }
 
-MATCHER_P(MaybeHasStringAction, m, "") {
+MATCHER_P(HasResult, m, "") {
   // Accepts a MaybeMatchResult argument.
   if (arg.match_state_ != MatchState::MatchComplete) {
     *result_listener << "match_state_ is not MatchComplete";
@@ -117,10 +117,10 @@ MATCHER_P(MaybeHasStringAction, m, "") {
     *result_listener << "result_ is null";
     return false;
   }
-  return ExplainMatchResult(IsStringAction(m), arg.result_, result_listener);
+  return ExplainMatchResult(m, arg.result_, result_listener);
 }
 
-MATCHER(MaybeHasNoMatch, "") {
+MATCHER(HasNoMatchResult, "") {
   // Accepts a MaybeMatchResult argument.
   if (arg.match_state_ != MatchState::MatchComplete) {
     *result_listener << "match_state_ is not MatchComplete";
@@ -133,7 +133,7 @@ MATCHER(MaybeHasNoMatch, "") {
   return true;
 }
 
-MATCHER(MaybeFailedMatch, "") {
+MATCHER(HasFailureResult, "") {
   // Accepts a MaybeMatchResult argument.
   if (arg.match_state_ != MatchState::UnableToMatch) {
     *result_listener << "match_state_ is not UnableToMatch";
@@ -192,7 +192,7 @@ matcher_tree:
   auto match_tree = factory_.create(matcher);
 
   MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, TestPrefixMatcher) {
@@ -239,7 +239,7 @@ matcher_tree:
   auto match_tree = factory_.create(matcher);
 
   const MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, TestInvalidFloatPrefixMapMatcher) {
@@ -434,7 +434,7 @@ on_no_match:
   auto match_tree = factory_.create(matcher);
 
   MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, CustomGenericInput) {
@@ -466,7 +466,7 @@ matcher_list:
   auto match_tree = factory_.create(matcher);
 
   MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, CustomMatcher) {
@@ -509,7 +509,7 @@ matcher_list:
   auto match_tree = factory_.create(matcher);
 
   MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, TestAndMatcher) {
@@ -566,7 +566,7 @@ matcher_tree:
   auto match_tree = factory_.create(matcher);
 
   MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, TestOrMatcher) {
@@ -623,7 +623,7 @@ matcher_tree:
   auto match_tree = factory_.create(matcher);
 
   MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, TestNotMatcher) {
@@ -660,7 +660,7 @@ matcher_list:
   auto match_tree = factory_.create(matcher);
 
   MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(result, MaybeHasNoMatch());
+  EXPECT_THAT(result, HasNoMatchResult());
 }
 
 TEST_F(MatcherTest, TestRecursiveMatcher) {
@@ -714,7 +714,7 @@ matcher_list:
 
   // evaluateMatch() handles recursion internally to return a final action.
   const auto recursive_result = evaluateMatch(*match_tree(), TestData());
-  EXPECT_THAT(recursive_result, MaybeHasStringAction("expected!"));
+  EXPECT_THAT(recursive_result, HasResult(IsStringAction("expected!")));
 }
 
 TEST_F(MatcherTest, RecursiveMatcherNoMatch) {
@@ -724,7 +724,7 @@ TEST_F(MatcherTest, RecursiveMatcherNoMatch) {
                      stringOnMatch<TestData>("match"));
 
   const auto recursive_result = evaluateMatch(matcher, TestData());
-  EXPECT_THAT(recursive_result, MaybeHasNoMatch());
+  EXPECT_THAT(recursive_result, HasNoMatchResult());
 }
 
 TEST_F(MatcherTest, RecursiveMatcherCannotMatch) {
@@ -736,7 +736,7 @@ TEST_F(MatcherTest, RecursiveMatcherCannotMatch) {
                      stringOnMatch<TestData>("match"));
 
   const auto recursive_result = evaluateMatch(matcher, TestData());
-  EXPECT_THAT(recursive_result, MaybeFailedMatch());
+  EXPECT_THAT(recursive_result, HasFailureResult());
 }
 
 // Parameterized to test both xDS and Envoy Matcher APIs for new features.
@@ -896,40 +896,40 @@ TEST_P(MatcherAmbiguousTest, ReentryWithRecursiveMatcher) {
     skipped_results.push_back(match.action_cb_);
   };
   MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result_1, MaybeHasStringAction("match-1"));
+  EXPECT_THAT(result_1, HasResult(IsStringAction("match-1")));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result_2, MaybeHasStringAction("match-2"));
+  EXPECT_THAT(result_2, HasResult(IsStringAction("match-2")));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult on_no_match_result_1 =
       reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(on_no_match_result_1, MaybeHasStringAction("on-no-match-nested-1"));
+  EXPECT_THAT(on_no_match_result_1, HasResult(IsStringAction("on-no-match-nested-1")));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result_3, MaybeHasStringAction("match-3"));
+  EXPECT_THAT(result_3, HasResult(IsStringAction("match-3")));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult result_4 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result_4, MaybeHasStringAction("match-4"));
+  EXPECT_THAT(result_4, HasResult(IsStringAction("match-4")));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult on_no_match_result_2 =
       reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(on_no_match_result_2, MaybeHasStringAction("on-no-match"));
+  EXPECT_THAT(on_no_match_result_2, HasResult(IsStringAction("on-no-match")));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult no_remaining_reentrants_result =
       reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(no_remaining_reentrants_result, MaybeHasNoMatch());
+  EXPECT_THAT(no_remaining_reentrants_result, HasNoMatchResult());
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 }
@@ -1097,25 +1097,25 @@ TEST_P(MatcherAmbiguousTest, ReentryWithNestedPreviewMatchers) {
     skipped_results.push_back(match.action_cb_);
   };
   MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result_1, MaybeHasStringAction("match 3"));
+  EXPECT_THAT(result_1, HasResult(IsStringAction("match 3")));
   EXPECT_THAT(skipped_results, AreStringActions(std::vector<std::string>{
                                    "skipped - keep matching 1", "skipped - match 2"}));
   skipped_results.clear();
 
   // Expect only the keep_matching nested matcher to be skipped from the second parent.
   MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result_2, MaybeHasStringAction("match 4"));
+  EXPECT_THAT(result_2, HasResult(IsStringAction("match 4")));
   EXPECT_THAT(skipped_results, AreStringActions(std::vector<std::string>{"keep matching 2"}));
   skipped_results.clear();
 
   MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result_3, MaybeHasStringAction("on no match"));
+  EXPECT_THAT(result_3, HasResult(IsStringAction("on no match")));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult no_remaining_reentrants_result =
       reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(no_remaining_reentrants_result, MaybeHasNoMatch());
+  EXPECT_THAT(no_remaining_reentrants_result, HasNoMatchResult());
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 }
@@ -1165,7 +1165,7 @@ TEST_P(MatcherAmbiguousTest, KeepMatchingWithUnsupportedReentry) {
     skipped_results.push_back(match.action_cb_);
   };
   MaybeMatchResult result = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
-  EXPECT_THAT(result, MaybeHasNoMatch());
+  EXPECT_THAT(result, HasNoMatchResult());
   EXPECT_THAT(skipped_results, AreStringActions(std::vector<std::string>{"keep matching"}));
 }
 

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -133,6 +133,19 @@ MATCHER(MaybeHasNoMatch, "") {
   return true;
 }
 
+MATCHER(MaybeFailedMatch, "") {
+  // Accepts a MaybeMatchResult argument.
+  if (arg.match_state_ != MatchState::UnableToMatch) {
+    *result_listener << "match_state_ is not UnableToMatch";
+    return false;
+  }
+  if (arg.result_ != nullptr) {
+    *result_listener << "result_ is not null";
+    return false;
+  }
+  return true;
+}
+
 using ::testing::IsEmpty;
 
 TEST_F(MatcherTest, TestMatcher) {
@@ -178,8 +191,8 @@ matcher_tree:
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.BoolValue"));
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasStringAction("expected!"));
+  MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, TestPrefixMatcher) {
@@ -225,8 +238,8 @@ matcher_tree:
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.BoolValue"));
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasStringAction("expected!"));
+  const MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, TestInvalidFloatPrefixMapMatcher) {
@@ -420,8 +433,8 @@ on_no_match:
 
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasStringAction("expected!"));
+  MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, CustomGenericInput) {
@@ -452,8 +465,8 @@ matcher_list:
   auto common_input_factory = TestCommonProtocolInputFactory("generic", "foo");
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasStringAction("expected!"));
+  MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, CustomMatcher) {
@@ -495,8 +508,8 @@ matcher_list:
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.BoolValue"));
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasStringAction("expected!"));
+  MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, TestAndMatcher) {
@@ -552,8 +565,8 @@ matcher_tree:
       .Times(2);
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasStringAction("expected!"));
+  MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, TestOrMatcher) {
@@ -609,8 +622,8 @@ matcher_tree:
       .Times(2);
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasStringAction("expected!"));
+  MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, TestNotMatcher) {
@@ -646,8 +659,8 @@ matcher_list:
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"));
   auto match_tree = factory_.create(matcher);
 
-  const auto result = match_tree()->match(TestData());
-  EXPECT_THAT(result, HasNoMatch());
+  MaybeMatchResult result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(result, MaybeHasNoMatch());
 }
 
 TEST_F(MatcherTest, TestRecursiveMatcher) {
@@ -695,12 +708,13 @@ matcher_list:
       .Times(2);
   auto match_tree = factory_.create(matcher);
 
+  // Show that a single match() call returns a sub-matcher instead of recursing.
   const auto result = match_tree()->match(TestData());
   EXPECT_THAT(result, HasSubMatcher());
 
-  const auto recursive_result = evaluateMatch(*(match_tree()), TestData());
-  EXPECT_EQ(recursive_result.match_state_, MatchState::MatchComplete);
-  EXPECT_THAT(recursive_result.result_, IsStringAction("expected!"));
+  // evaluateMatch() handles recursion internally to return a final action.
+  const auto recursive_result = evaluateMatch(*match_tree(), TestData());
+  EXPECT_THAT(recursive_result, MaybeHasStringAction("expected!"));
 }
 
 TEST_F(MatcherTest, RecursiveMatcherNoMatch) {
@@ -710,8 +724,7 @@ TEST_F(MatcherTest, RecursiveMatcherNoMatch) {
                      stringOnMatch<TestData>("match"));
 
   const auto recursive_result = evaluateMatch(matcher, TestData());
-  EXPECT_EQ(recursive_result.match_state_, MatchState::MatchComplete);
-  EXPECT_EQ(recursive_result.result_, nullptr);
+  EXPECT_THAT(recursive_result, MaybeHasNoMatch());
 }
 
 TEST_F(MatcherTest, RecursiveMatcherCannotMatch) {
@@ -723,8 +736,7 @@ TEST_F(MatcherTest, RecursiveMatcherCannotMatch) {
                      stringOnMatch<TestData>("match"));
 
   const auto recursive_result = evaluateMatch(matcher, TestData());
-  EXPECT_EQ(recursive_result.match_state_, MatchState::UnableToMatch);
-  EXPECT_EQ(recursive_result.result_, nullptr);
+  EXPECT_THAT(recursive_result, MaybeFailedMatch());
 }
 
 // Parameterized to test both xDS and Envoy Matcher APIs for new features.
@@ -733,129 +745,129 @@ INSTANTIATE_TEST_SUITE_P(UseXdsMatcherType, MatcherAmbiguousTest, ::testing::Boo
 
 TEST_P(MatcherAmbiguousTest, ReentryWithRecursiveMatcher) {
   const std::string yaml = R"EOF(
-matcher_list:
-  matchers:
-  - on_match:
-      matcher:
-        matcher_list:
-          matchers:
-          - on_match:
+    matcher_list:
+      matchers:
+      - on_match:
+          matcher:
+            matcher_list:
+              matchers:
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: match-1
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: no-match-1
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: bar
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: match-2
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+            on_no_match:
               action:
                 name: test_action
                 typed_config:
                   "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: match-1
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: no-match-1
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: bar
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: match-2
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-        on_no_match:
-          action:
-            name: test_action
-            typed_config:
-              "@type": type.googleapis.com/google.protobuf.StringValue
-              value: on-no-match-nested-1
-    predicate:
-      single_predicate:
-        input:
-          name: inner_input
-          typed_config:
-            "@type": type.googleapis.com/google.protobuf.StringValue
-        value_match:
-          exact: foo
-  - on_match:
-      matcher:
-        matcher_list:
-          matchers:
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: match-3
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: no-match-2
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: bar
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: match-4
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-    predicate:
-      single_predicate:
-        input:
-          name: inner_input
-          typed_config:
-            "@type": type.googleapis.com/google.protobuf.StringValue
-        value_match:
-          exact: foo
-on_no_match:
-  action:
-    name: test_action
-    typed_config:
-      "@type": type.googleapis.com/google.protobuf.StringValue
-      value: on-no-match
-  )EOF";
+                  value: on-no-match-nested-1
+        predicate:
+          single_predicate:
+            input:
+              name: inner_input
+              typed_config:
+                "@type": type.googleapis.com/google.protobuf.StringValue
+            value_match:
+              exact: foo
+      - on_match:
+          matcher:
+            matcher_list:
+              matchers:
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: match-3
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: no-match-2
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: bar
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: match-4
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+        predicate:
+          single_predicate:
+            input:
+              name: inner_input
+              typed_config:
+                "@type": type.googleapis.com/google.protobuf.StringValue
+            value_match:
+              exact: foo
+    on_no_match:
+      action:
+        name: test_action
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.StringValue
+          value: on-no-match
+      )EOF";
 
   // Exercise both xDS and Envoy Matcher APIs, based on the test parameter.
   xds::type::matcher::v3::Matcher xds_matcher;
@@ -880,40 +892,43 @@ on_no_match:
   // Expect to hit each match once via repeated re-entry, including the recursive on-no-match.
   ReenterableMatchEvaluator<TestData> reenterable_matcher(top_matcher, false);
   std::vector<ActionFactoryCb> skipped_results;
-  MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  SkippedMatchCb<TestData> skipped_match_cb = [&skipped_results](const OnMatch<TestData>& match) {
+    skipped_results.push_back(match.action_cb_);
+  };
+  MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result_1, MaybeHasStringAction("match-1"));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
-  MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result_2, MaybeHasStringAction("match-2"));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult on_no_match_result_1 =
-      reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+      reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(on_no_match_result_1, MaybeHasStringAction("on-no-match-nested-1"));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
-  MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result_3, MaybeHasStringAction("match-3"));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
-  MaybeMatchResult result_4 = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  MaybeMatchResult result_4 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result_4, MaybeHasStringAction("match-4"));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult on_no_match_result_2 =
-      reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+      reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(on_no_match_result_2, MaybeHasStringAction("on-no-match"));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult no_remaining_reentrants_result =
-      reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+      reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(no_remaining_reentrants_result, MaybeHasNoMatch());
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
@@ -924,132 +939,132 @@ TEST_P(MatcherAmbiguousTest, ReentryWithNestedPreviewMatchers) {
   // recorded. Second parent matcher is not set to skip matches, so nested matchers determine
   // skipping behaviors.
   const std::string yaml = R"EOF(
-matcher_list:
-  matchers:
-  - on_match:
-      keep_matching: true
-      matcher:
-        matcher_list:
-          matchers:
-          - on_match:
+    matcher_list:
+      matchers:
+      - on_match:
+          keep_matching: true
+          matcher:
+            matcher_list:
+              matchers:
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: skipped - no match 1
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: bar
+              - on_match:
+                  keep_matching: true
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: skipped - keep matching 1
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: skipped - match 2
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+            on_no_match:
               action:
                 name: test_action
                 typed_config:
                   "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: skipped - no match 1
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: bar
-          - on_match:
-              keep_matching: true
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: skipped - keep matching 1
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: skipped - match 2
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-        on_no_match:
-          action:
-            name: test_action
-            typed_config:
-              "@type": type.googleapis.com/google.protobuf.StringValue
-              value: skipped - nested on no match 1
-    predicate:
-      single_predicate:
-        input:
-          name: inner_input
-          typed_config:
-            "@type": type.googleapis.com/google.protobuf.StringValue
-        value_match:
-          exact: foo
-  - on_match:
-      matcher:
-        matcher_list:
-          matchers:
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: match 3
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-          - on_match:
-              keep_matching: true
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: keep matching 2
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-          - on_match:
-              action:
-                name: test_action
-                typed_config:
-                  "@type": type.googleapis.com/google.protobuf.StringValue
-                  value: match 4
-            predicate:
-              single_predicate:
-                input:
-                  name: inner_input
-                  typed_config:
-                    "@type": type.googleapis.com/google.protobuf.StringValue
-                value_match:
-                  exact: foo
-    predicate:
-      single_predicate:
-        input:
-          name: inner_input
-          typed_config:
-            "@type": type.googleapis.com/google.protobuf.StringValue
-        value_match:
-          exact: foo
-on_no_match:
-  action:
-    name: test_action
-    typed_config:
-      "@type": type.googleapis.com/google.protobuf.StringValue
-      value: on no match
-  )EOF";
+                  value: skipped - nested on no match 1
+        predicate:
+          single_predicate:
+            input:
+              name: inner_input
+              typed_config:
+                "@type": type.googleapis.com/google.protobuf.StringValue
+            value_match:
+              exact: foo
+      - on_match:
+          matcher:
+            matcher_list:
+              matchers:
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: match 3
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+              - on_match:
+                  keep_matching: true
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: keep matching 2
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+              - on_match:
+                  action:
+                    name: test_action
+                    typed_config:
+                      "@type": type.googleapis.com/google.protobuf.StringValue
+                      value: match 4
+                predicate:
+                  single_predicate:
+                    input:
+                      name: inner_input
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                    value_match:
+                      exact: foo
+        predicate:
+          single_predicate:
+            input:
+              name: inner_input
+              typed_config:
+                "@type": type.googleapis.com/google.protobuf.StringValue
+            value_match:
+              exact: foo
+    on_no_match:
+      action:
+        name: test_action
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.StringValue
+          value: on no match
+      )EOF";
 
   // Exercise both xDS and Envoy Matcher APIs, based on the test parameter.
   xds::type::matcher::v3::Matcher xds_matcher;
@@ -1078,25 +1093,28 @@ on_no_match:
   // if the parent matcher wasn't skipped.
   ReenterableMatchEvaluator<TestData> reenterable_matcher(top_matcher, false);
   std::vector<ActionFactoryCb> skipped_results;
-  MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  SkippedMatchCb<TestData> skipped_match_cb = [&skipped_results](const OnMatch<TestData>& match) {
+    skipped_results.push_back(match.action_cb_);
+  };
+  MaybeMatchResult result_1 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result_1, MaybeHasStringAction("match 3"));
   EXPECT_THAT(skipped_results, AreStringActions(std::vector<std::string>{
                                    "skipped - keep matching 1", "skipped - match 2"}));
   skipped_results.clear();
 
   // Expect only the keep_matching nested matcher to be skipped from the second parent.
-  MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  MaybeMatchResult result_2 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result_2, MaybeHasStringAction("match 4"));
   EXPECT_THAT(skipped_results, AreStringActions(std::vector<std::string>{"keep matching 2"}));
   skipped_results.clear();
 
-  MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  MaybeMatchResult result_3 = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result_3, MaybeHasStringAction("on no match"));
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
 
   MaybeMatchResult no_remaining_reentrants_result =
-      reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+      reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(no_remaining_reentrants_result, MaybeHasNoMatch());
   EXPECT_THAT(skipped_results, IsEmpty());
   skipped_results.clear();
@@ -1106,21 +1124,21 @@ TEST_P(MatcherAmbiguousTest, KeepMatchingWithUnsupportedReentry) {
   // ExactMapMatcher does not support reentry, so we expect a no-match result when hitting a
   // keep_matching matcher.
   const std::string yaml = R"EOF(
-matcher_tree:
-  input:
-    name: inner_input
-    typed_config:
-      "@type": type.googleapis.com/google.protobuf.StringValue
-  exact_match_map:
-    map:
-      foo:
-        keep_matching: true
-        action:
-          name: test_action
-          typed_config:
-            "@type": type.googleapis.com/google.protobuf.StringValue
-            value: keep matching
-  )EOF";
+    matcher_tree:
+      input:
+        name: inner_input
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.StringValue
+      exact_match_map:
+        map:
+          foo:
+            keep_matching: true
+            action:
+              name: test_action
+              typed_config:
+                "@type": type.googleapis.com/google.protobuf.StringValue
+                value: keep matching
+      )EOF";
 
   // Exercise both xDS and Envoy Matcher APIs, based on the test parameter.
   xds::type::matcher::v3::Matcher xds_matcher;
@@ -1143,7 +1161,10 @@ matcher_tree:
 
   ReenterableMatchEvaluator<TestData> reenterable_matcher(matcher, false);
   std::vector<ActionFactoryCb> skipped_results;
-  MaybeMatchResult result = reenterable_matcher.evaluateMatch(TestData(), skipped_results);
+  SkippedMatchCb<TestData> skipped_match_cb = [&skipped_results](const OnMatch<TestData>& match) {
+    skipped_results.push_back(match.action_cb_);
+  };
+  MaybeMatchResult result = reenterable_matcher.evaluateMatch(TestData(), skipped_match_cb);
   EXPECT_THAT(result, MaybeHasNoMatch());
   EXPECT_THAT(skipped_results, AreStringActions(std::vector<std::string>{"keep matching"}));
 }


### PR DESCRIPTION
Commit Message: Centralize keep_matching & sub-matcher recursion handling in evaluateMatch(...)

Additional Description: Previously, individual MatchTree children had different behaviors regarding sub-matcher recursion. TrieMatcher and MapMatcher both handled sub-matcher recursion internally while ListMatcher relied on the handling in `evaluateMatch(...)`. Rather than create a contract that all Matchers must know to handle their own recursion internally, the behavior is instead centralized in `evaluateMatch(...)`, leaving the Matchers to do the bare minimum: find the first match and return with a reentrant if appropriate.

For TrieMatcher in particular, the internal recursion was needed to continue iterating over the vector of matches if a sub-matcher provided a no-match. As this behavior is already built into re-entry + keep_matching handling for `evaluateMatch(...)`, this requirement could be met by implementing a TrieMatcherReentrant.

Additional notes:
- Unrelated, but this PR also changes the way that skipped matches are tracked. Instead of implicitly doing vector re-sizing, skipped-matches instead go to a provided callback.